### PR TITLE
Fix code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/backend/src/main/java/cz/forgottenempire/servermanager/security/WebSecurityConfig.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/security/WebSecurityConfig.java
@@ -75,7 +75,7 @@ class WebSecurityConfig {
         JWTAuthenticationFilter jwtAuthenticationFilter = new JWTAuthenticationFilter(authenticationManager(authenticationConfiguration));
         jwtAuthenticationFilter.setFilterProcessesUrl("/api/login");
 
-        return http.csrf(AbstractHttpConfigurer::disable)
+        return http.csrf(Customizer.withDefaults())
                 .authorizeHttpRequests(request -> request.requestMatchers(
                                 antMatcher("/api/login"),
                                 not(antMatcher("/api/**"))


### PR DESCRIPTION
Fixes [https://github.com/Fyuran/arma-server-manager/security/code-scanning/1](https://github.com/Fyuran/arma-server-manager/security/code-scanning/1)

To fix the problem, we need to enable CSRF protection in the `WebSecurityConfig` class. This involves removing the line that disables CSRF protection and ensuring that CSRF protection is configured correctly. We will modify the `filterChain` method to enable CSRF protection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
